### PR TITLE
ci(update-version): fix ignore conflicts mechanism

### DIFF
--- a/.github/workflows/_reusable_update_version.yml
+++ b/.github/workflows/_reusable_update_version.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
+          cache: maven
 
       - name: Setup Maven
         uses: bonitasoft/maven-settings-action@v1
@@ -45,35 +46,10 @@ jobs:
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 
+      # Add [ignore-conflicts] keyword to commit body message to be read by merge_upstream workflow
       - name: Commit and push
         run: |
-          git commit -a -m "chore(versioning): update version to ${{ inputs.version }}"
-          git push
-
-  merge-upstream:
-    needs: update-version
-    if: ${{ inputs.merge-upstream-ignoring-conflicts }}
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Setup git
-        uses: bonitasoft/git-setup-action@v1
-        with:
-          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
-
-      - name: Determine upstream branch
-        id: upstream-branch
-        run: echo "ref=${{ fromJson(vars.SUPPORTED_BRANCHES).upstream-branch[github.ref_name] }}" >> $GITHUB_OUTPUT
-
-      - name: Checkout upstream branch
-        uses: actions/checkout@v4
-        with:
-          repository: bonitasoft/bonita-user-application
-          ref: ${{ steps.upstream-branch.outputs.ref }}
-          fetch-depth: 0
-          token: ${{ secrets.BONITA_CI_PAT }}
-
-      - name: Merge upstream branch
-        run: |
-          git config merge.ours.driver true
-          git merge origin/${{ github.ref_name }} -X ours  -m "chore(merge): ${{ github.ref_name }} into ${{ steps.upstream-branch.outputs.ref }}"
+          git commit -a \
+            -m "chore(versioning): update version to ${{ inputs.version }}" \
+            ${{ inputs.merge-upstream-ignoring-conflicts && '-m "[ignore-conflicts]"' || '' }}
           git push

--- a/.github/workflows/merge_upstream.yml
+++ b/.github/workflows/merge_upstream.yml
@@ -1,3 +1,6 @@
+# This workflow merges changes from downstream branches to upstream branches.
+# If a commit contains [ignore-conflicts] in its message, conflicts will be
+# automatically resolved using the "ours" merge strategy.
 name: Merge Upstream
 
 on:
@@ -11,4 +14,7 @@ on:
 jobs:
   merge-upstream:
     uses: bonitasoft/github-workflows/.github/workflows/_reusable_merge_upstream.yml@main
+    with:
+      # Ignore conflicts if the keyword [ignore-conflicts] is present in the commit message
+      ignore-conflicts: ${{ contains(github.event.head_commit.message, '[ignore-conflicts]') }}
     secrets: inherit


### PR DESCRIPTION
By committing the updated version modifications, it triggers the merge_upstream workflow automatically. The commit now contains a keyword to be detected by the merge_upstream workflow.

Related to issue https://github.com/bonitasoft/serenity/issues/217

:warning: **DO NOT MERGE THIS PR WITH THE KEYWORD IN THE MERGE COMMIT MESSAGE !!**