### PR TITLE
feat(subscription): add Delegations menu and page-user-delegation

### DIFF
--- a/subscription/pom.xml
+++ b/subscription/pom.xml
@@ -29,4 +29,13 @@
         <application.version>8.0</application.version>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.bonitasoft.web.page</groupId>
+            <artifactId>page-user-delegation</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/subscription/src/main/resources/bonita-distrib/bonita-user-application-sp.xml
+++ b/subscription/src/main/resources/bonita-distrib/bonita-user-application-sp.xml
@@ -9,6 +9,7 @@
             <applicationPage customPage="custompage_tasklist" token="task-list"/>
             <applicationPage customPage="custompage_userCaseListBonita" token="case-list"/>
             <applicationPage customPage="custompage_processlistBonita" token="process-list"/>
+            <applicationPage customPage="custompage_userDelegationBonita" token="delegation"/>
         </applicationPages>
         <applicationMenus>
             <applicationMenu applicationPage="task-list">
@@ -19,6 +20,9 @@
             </applicationMenu>
             <applicationMenu applicationPage="process-list">
                 <displayName>Processes</displayName>
+            </applicationMenu>
+            <applicationMenu applicationPage="delegation">
+                <displayName>Delegations</displayName>
             </applicationMenu>
         </applicationMenus>
     </application>

--- a/subscription/src/main/resources/bos-distrib/applications/bonita-user-application-sp.xml
+++ b/subscription/src/main/resources/bos-distrib/applications/bonita-user-application-sp.xml
@@ -9,6 +9,7 @@
             <applicationPage customPage="custompage_tasklist" token="task-list"/>
             <applicationPage customPage="custompage_UserCaseListBonitaV15" token="case-list"/>
             <applicationPage customPage="custompage_processlistBonita" token="process-list"/>
+            <applicationPage customPage="custompage_userDelegationBonita" token="delegation"/>
         </applicationPages>
         <applicationMenus>
             <applicationMenu applicationPage="task-list">
@@ -19,6 +20,9 @@
             </applicationMenu>
             <applicationMenu applicationPage="process-list">
                 <displayName>Processes</displayName>
+            </applicationMenu>
+            <applicationMenu applicationPage="delegation">
+                <displayName>Delegations</displayName>
             </applicationMenu>
         </applicationMenus>
     </application>


### PR DESCRIPTION
## Context

Follow-up to the community/subscription split (#102). Adds the first subscription-only page so the EE edition exposes a Delegations section that the community edition does not.

> Stacked on `feat/community-subscription-split` (#102) so this diff shows only the delegation change. GitHub will retarget to `dev` automatically once #102 merges.

## Changes

- **`subscription/pom.xml`**: declare the `page-user-delegation` dependency (groupId `com.bonitasoft.web.page`, `type` zip, `${project.version}`).
- **Both subscription descriptors** (`bonita-distrib/bonita-user-application-sp.xml` and `bos-distrib/applications/bonita-user-application-sp.xml`):
  - new application page `custompage_userDelegationBonita` with token `delegation`;
  - new top-level menu **Delegations** pointing to that page.

Community descriptors are untouched - this is subscription-only.

## Verification

- Both descriptors validated as well-formed XML.
- A full `mvnw verify` is **not** possible yet: the `page-user-delegation` artifact is not published to the Bonita repository, so dependency resolution would fail. The build should be re-run once that artifact is available.

Relates to [BPA-344](https://bonitasoft.atlassian.net/browse/BPA-344)

[BPA-344]: https://bonitasoft.atlassian.net/browse/BPA-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ