### PR TITLE
chore: update layout reference to V25

### DIFF
--- a/community/src/main/resources/bos-distrib/applications/bonita-user-application.xml
+++ b/community/src/main/resources/bos-distrib/applications/bonita-user-application.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <applications xmlns="http://documentation.bonitasoft.com/application-xml-schema/1.1">
-    <application token="userApp" version="${application.version}" profile="User" homePage="task-list" state="ACTIVATED" layout="custompage_BonitaLayoutV24" theme="custompage_themeBonita">
+    <application token="userApp" version="${application.version}" profile="User" homePage="task-list" state="ACTIVATED" layout="custompage_BonitaLayoutV25" theme="custompage_themeBonita">
         <displayName>${name}</displayName>
         <description>${description}</description>
         <iconPath>bonita-user-application.png</iconPath>

--- a/subscription/src/main/resources/bos-distrib/applications/bonita-user-application-sp.xml
+++ b/subscription/src/main/resources/bos-distrib/applications/bonita-user-application-sp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <applications xmlns="http://documentation.bonitasoft.com/application-xml-schema/1.1">
-    <application token="userAppEE" version="${application.version}" profile="User" homePage="task-list" state="ACTIVATED" layout="custompage_BonitaLayoutV24" theme="custompage_themeBonita">
+    <application token="userAppEE" version="${application.version}" profile="User" homePage="task-list" state="ACTIVATED" layout="custompage_BonitaLayoutV25" theme="custompage_themeBonita">
         <displayName>${name}</displayName>
         <description>${description}</description>
         <iconPath>bonita-user-application.png</iconPath>


### PR DESCRIPTION
## What

Update the `bos-distrib` application descriptors to reference the layout page by its new versioned id `custompage_BonitaLayoutV25` (was `custompage_BonitaLayoutV24`).

Both variants are updated:
- `community/.../bos-distrib/applications/*.xml`
- `subscription/.../bos-distrib/applications/*.xml`

The `bonita-distrib` variants reference the layout by its stable id `custompage_layoutBonita` and are intentionally left unchanged.

## Why

The Bonita layout page was bumped `V24 -> V25` in `bonita-web-pages` (adding the `Delegations` and `Data retention (GDPR)` application-menu translations). The page name `BonitaLayoutV25` produces the deployed id `custompage_BonitaLayoutV25`, so the descriptors that pin the versioned id must follow or they would resolve a stale/missing layout once V25 ships.

## Coordination

Should be merged together with the `bonita-web-pages` layout bump.